### PR TITLE
git commit -m "Add Linux-only access middleware

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"btwarch/config"
 	"btwarch/database"
 	"btwarch/routes/auth"
+	"btwarch/middleware" 
 	"log"
 
 	"github.com/gofiber/fiber/v2"
@@ -38,6 +39,7 @@ func main() {
 	})
 
 	app.Use(logger.New())
+	app.Use(middleware.LinuxOnlyMiddleware())
 
 	auth.InitRouter(app)
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,8 @@ type Config struct {
 	GitHubClientID     string
 	GitHubClientSecret string
 	GitHubRedirectURL  string
+	CloudFlareZoneId   string
+	CloudFlareToken	   string
 	JWTSecret          string
 	DatabaseURL        string
 	Port               string
@@ -18,6 +20,8 @@ func LoadConfig() *Config {
 		GitHubClientID:     getEnv("GITHUB_CLIENT_ID", ""),
 		GitHubClientSecret: getEnv("GITHUB_CLIENT_SECRET", ""),
 		GitHubRedirectURL:  getEnv("GITHUB_REDIRECT_URL", "http://localhost:8080/auth/github/callback"),
+		CloudFlareZoneId:   getEnv("CLOUDFLARE_ZONE_ID",""),
+		CloudFlareToken:	getEnv("CLOUDFLARE_TOKEN",""),
 		JWTSecret:          getEnv("JWT_SECRET", ""),
 		DatabaseURL:        getEnv("DATABASE_URL", "postgres://btwarch:btwarch@localhost:5432/btwarch?sslmode=disable"),
 		Port:               getEnv("PORT", "8080"),

--- a/middleware/linux_middleware.go
+++ b/middleware/linux_middleware.go
@@ -1,0 +1,28 @@
+package middleware
+import (
+	"strings"
+	"github.com/gofiber/fiber/v2"
+)
+
+func LinuxOnlyMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		userAgent := c.Get("User-Agent")
+		blocked := []string{"Android", "Macintosh", "iPhone", "iPad", "Windows"}
+
+		for _, b := range blocked {
+			if strings.Contains(userAgent, b) {
+				return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+					"error": "Access denied: only Linux users allowed",
+				})
+			}
+		}
+
+		if !strings.Contains(userAgent, "Linux") {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "Access denied: only Linux users allowed",
+			})
+		}
+
+		return c.Next()
+	}
+}


### PR DESCRIPTION
## Description
Add Linux-only access middleware to restrict API access to Linux users only.

## Changes Made
- Created `LinuxOnlyMiddleware()` in middleware package
- Blocks requests from Android, macOS, iOS, Windows user agents
- Applied middleware globally in `main.go`
- Returns 403 Forbidden with descriptive error message