### PR TITLE
chore: downgrade GitHub Actions versions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,15 +14,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -34,7 +34,7 @@ jobs:
           make build-linux
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.BINARY_NAME }}_linux_amd64
           path: bin/${{ env.BINARY_NAME }}_linux_amd64
@@ -45,10 +45,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: ${{ env.BINARY_NAME }}_linux_amd64
           path: bin/


### PR DESCRIPTION
- Downgraded actions/checkout from v4 to v3.
- Downgraded actions/setup-go from v4 to v3.
- Downgraded actions/cache from v3 to v2.
- Downgraded actions/upload-artifact from v3 to v2.
- Downgraded actions/download-artifact from v3 to v2.