### PR TITLE
chore: upgrade GitHub Actions versions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -34,7 +34,7 @@ jobs:
           make build-linux
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.BINARY_NAME }}_linux_amd64
           path: bin/${{ env.BINARY_NAME }}_linux_amd64
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.BINARY_NAME }}_linux_amd64
           path: bin/

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,12 @@
+name: Healthcheck
+
+on:
+  workflow_dispatch:
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Healthcheck
+        run: |
+          curl -s http://api.btwarch.me/health | grep -q "OK"


### PR DESCRIPTION
- Upgraded actions/cache from v2 to v3.
- Upgraded actions/upload-artifact from v2 to v3.
- Upgraded actions/download-artifact from v2 to v3.