### PR TITLE
chore: upgrade GitHub Actions versions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           make build-linux
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BINARY_NAME }}_linux_amd64
           path: bin/${{ env.BINARY_NAME }}_linux_amd64
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.BINARY_NAME }}_linux_amd64
           path: bin/


### PR DESCRIPTION
- Upgraded actions/upload-artifact from v3 to v4.
- Upgraded actions/download-artifact from v3 to v4.