### PR TITLE
chore: update build command in deploy workflow for binary output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,10 @@ jobs:
 
       - name: Build binary
         run: |
-          make build-linux
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+            -ldflags="-s -w" \
+            -o bin/${{ env.BINARY_NAME }}_linux_amd64 \
+            ./cmd/app/main.go
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Modified the build command in the GitHub Actions deploy workflow to set CGO_ENABLED, GOOS, and GOARCH for cross-compilation.
- Updated the output binary name and location to align with the new structure in the Makefile.