### PR TITLE
refactor: streamline deploy workflow by consolidating steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,10 @@ env:
   BINARY_NAME: btwarch
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: production
     steps:
       - uses: actions/checkout@v3
 
@@ -21,45 +23,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Build binary
         run: |
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
             -ldflags="-s -w" \
-            -o bin/${{ env.BINARY_NAME }}_linux_amd64 \
+            -o ${{ env.BINARY_NAME }}_linux_amd64 \
             ./cmd/app/main.go
 
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.BINARY_NAME }}_linux_amd64
-          path: bin/${{ env.BINARY_NAME }}_linux_amd64
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    environment: production
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download binary artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.BINARY_NAME }}_linux_amd64
-          path: bin/
-
-      - name: Make binary executable
-        run: chmod +x bin/${{ env.BINARY_NAME }}_linux_amd64
-
-      - name: Configure SSH
+      - name: Configure SSH and Deploy
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -72,40 +43,12 @@ jobs:
           echo "  IdentityFile ~/.ssh/deploy_key" >> ~/.ssh/config
           echo "  StrictHostKeyChecking no" >> ~/.ssh/config
 
-      - name: Create backup
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-        run: |
           ssh $SSH_USER@$SSH_HOST 'mkdir -p ~/btwarch/app/backups'
           ssh $SSH_USER@$SSH_HOST 'cp ~/btwarch/app/btwarch_linux_amd64 ~/btwarch/app/backups/btwarch_linux_amd64.backup.$(date +%Y%m%d_%H%M%S)' || true
 
-      - name: Deploy binary
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-        run: |
-          rsync -avz --progress bin/${{ env.BINARY_NAME }}_linux_amd64 $SSH_USER@$SSH_HOST:~/btwarch/app/
+          rsync -avz --progress ${{ env.BINARY_NAME }}_linux_amd64 $SSH_USER@$SSH_HOST:~/btwarch/app/
           ssh $SSH_USER@$SSH_HOST 'chmod +x ~/btwarch/app/btwarch_linux_amd64'
+          ssh $SSH_USER@$SSH_HOST 'sudo systemctl restart btwarch && sudo systemctl reload nginx'
+          ssh $SSH_USER@$SSH_HOST 'systemctl is-active btwarch && systemctl is-active nginx'
 
-      - name: Restart services
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-        run: |
-          ssh $SSH_USER@$SSH_HOST 'sudo systemctl restart btwarch'
-          ssh $SSH_USER@$SSH_HOST 'sudo systemctl reload nginx'
-
-      - name: Verify deployment
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-        run: |
-          ssh $SSH_USER@$SSH_HOST 'systemctl is-active btwarch'
-          ssh $SSH_USER@$SSH_HOST 'systemctl is-active nginx'
-
-      - name: Clean up
-        if: always()
-        run: |
-          rm -f ~/.ssh/deploy_key
-          rm -f ~/.ssh/config
+          rm -f ~/.ssh/deploy_key ~/.ssh/config


### PR DESCRIPTION
- Renamed the build job to deploy and removed unnecessary caching and artifact upload steps.
- Simplified the deployment process by directly building and deploying the binary without intermediate steps.
- Added commands to restart services and verify their status post-deployment.